### PR TITLE
renames output bin from nebula-cli to nebula

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ CLI_DIST_TARGETS ?= linux-amd64 linux-386 linux-arm64 linux-ppc64le linux-s390x 
 #
 #
 
-CLI_DIST_NAME := nebula-cli
+CLI_DIST_NAME := nebula
 CLI_DIST_VERSION ?= $(shell $(GIT) describe --tags --always --dirty)
 
 DEPEND_DIR := .depend


### PR DESCRIPTION
Nothing in the wild appends -cli to their tools. And if they do, they
are usually poorly designed tools. It's implied already that this is a
command line interface. Lets just ditch the postfix and make it look a
little less cheesy. :^)