### PR TITLE
Improvements to workflow subcommand

### DIFF
--- a/pkg/client/workflow.go
+++ b/pkg/client/workflow.go
@@ -153,7 +153,7 @@ func (c *Client) RunWorkflow(name string, params map[string]string) (*RunWorkflo
 }
 
 // DownloadWorkflow gets the latest configuration (as a YAML string) for a
-// given workflow name. This is very purppose-built and likely rather frail. We
+// given workflow name. This is very purpose-built and likely rather frail. We
 // should probably not be doing this this way.
 func (c *Client) DownloadWorkflow(name string) (string, errors.Error) {
 	workflow, err := c.GetWorkflow(name)

--- a/pkg/cmd/workflow.go
+++ b/pkg/cmd/workflow.go
@@ -269,13 +269,9 @@ func doDownloadWorkflow(cmd *cobra.Command, args []string) error {
 	filepath, nil := cmd.Flags().GetString("file")
 
 	if filepath == "" {
-		// Just plop the whole thing out output.
 		Dialog.WriteString(body)
 	} else {
-		// make a byte array out of the body to feed to the writer
-		contents := []byte(body)
-		err := ioutil.WriteFile(filepath, contents, 0644)
-		if err != nil {
+		if err := ioutil.WriteFile(filepath, []byte(body), 0644); err != nil {
 			debug.Logf("failed to write to file %s: %s", filepath, err.Error())
 			return err
 		}


### PR DESCRIPTION
Adds a `-f` option to `relay workflow download` for specifying
output file, to match the other `relay workflow *` commands

Adds a shortcut `-p` for `--parameter` on `relay workflow run`

Closes #33 