### PR TITLE
Updates for PN-706 - add documentation for the CLI

### DIFF
--- a/docs/generate.go
+++ b/docs/generate.go
@@ -1,0 +1,3 @@
+package docs
+
+//go:generate go run ../cmd/relay doc generate -f relay.md

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -1,0 +1,61 @@
+## relay
+
+Relay by Puppet
+
+### Synopsis
+
+Relay connects your tools, APIs, and infrastructure
+to automate common tasks through simple, event-driven workflows.
+
+To get started, you'll need a relay.sh account - sign up for free
+by following this link: 🔗 https://relay.sh/
+
+Once you've signed up, run this to log in:
+▶️   relay auth login
+
+Use the 'workflow' subcommand to interact with workflows:
+▶️   relay workflow
+
+
+### Subcommand Usage
+
+**`relay auth login [email] [flags]`** -- Log in to Relay
+```
+  -p, --password-stdin   accept password from stdin
+```
+
+**`relay auth logout`** -- Log out of Relay
+
+**`relay doc generate`** -- Generate markdown documentation to stdout
+
+**`relay workflow add [workflow name] [flags]`** -- Add a Relay workflow from a local file
+```
+  -f, --file string   Path to Relay workflow file
+```
+
+**`relay workflow delete [workflow name]`** -- Delete a Relay workflow
+
+**`relay workflow download [workflow name] [flags]`** -- Download a workflow from the service
+```
+  -f, --file string   Filename to write workflow, relative to current working dir
+```
+
+**`relay workflow list`** -- Get a list of all your workflows
+
+**`relay workflow replace [workflow name] [flags]`** -- Replace an existing Relay workflow
+```
+  -f, --file string   Path to Relay workflow file
+```
+
+**`relay workflow run [workflow name] [flags]`** -- Invoke a Relay workflow
+```
+  -p, --parameter stringArray   Parameters to invoke this workflow run with
+```
+
+### Global flags
+```
+  -d, --debug        print debugging information
+  -o, --out string   output type: (text|json) (default "text")
+  -y, --yes          skip confirmation prompts
+
+```

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -26,7 +26,10 @@ Use the 'workflow' subcommand to interact with workflows:
 
 **`relay auth logout`** -- Log out of Relay
 
-**`relay doc generate`** -- Generate markdown documentation to stdout
+**`relay doc generate [flags]`** -- Generate markdown documentation to stdout
+```
+  -f, --file string   The path to a file to write the documentation to
+```
 
 **`relay workflow add [workflow name] [flags]`** -- Add a Relay workflow from a local file
 ```

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,7 @@ github.com/coreos/go-oidc v2.2.1+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHo
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/dave/jennifer v0.0.0-20171004025221-97587ff16f68 h1:kO0EmtIiU1BiIMqtO41nHJL/0MPBBPz3PUOy/dWw3aM=
@@ -320,6 +321,7 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/serenize/snaker v0.0.0-20171002133257-c7a77c38c398 h1:BbvM3zbEZXBScbJawRAPLkmc44D1KUi/zR5NIBPOWMI=
 github.com/serenize/snaker v0.0.0-20171002133257-c7a77c38c398/go.mod h1:Yow6lPLSAXx2ifx470yD/nUe22Dv5vBvxK/UK9UUTVs=

--- a/pkg/cmd/doc.go
+++ b/pkg/cmd/doc.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"bytes"
+	"io/ioutil"
 
+	"github.com/puppetlabs/relay/pkg/debug"
 	"github.com/spf13/cobra"
 )
 
@@ -25,6 +27,8 @@ func newGenerateCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE:  genDocs,
 	}
+
+	cmd.Flags().StringP("file", "f", "", "The path to a file to write the documentation to")
 
 	return cmd
 }
@@ -116,7 +120,18 @@ func genDocs(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		Dialog.Errorf("problem generating markdown: %s", err.Error)
 	}
-	Dialog.WriteString(markdown)
+
+	file, err := cmd.Flags().GetString("file")
+	if err != nil {
+		return err
+	}
+
+	if file == "" {
+		Dialog.WriteString(markdown)
+	} else if err := ioutil.WriteFile(file, []byte(markdown), 0644); err != nil {
+		debug.Logf("failed to write to file %s: %s", file, err.Error())
+		return err
+	}
 
 	return nil
 

--- a/pkg/cmd/doc.go
+++ b/pkg/cmd/doc.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+func newDocCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "doc",
+		Short: "generate docs for relay",
+		Args:  cobra.MinimumNArgs(1),
+	}
+
+	cmd.AddCommand(newGenerateCommand())
+
+	return cmd
+}
+
+func newGenerateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "generate",
+		Short: "Generate documentation",
+		Args:  cobra.NoArgs,
+		RunE:  genDocs,
+	}
+
+	cmd.Flags().StringP("format", "f", "markdown", "format of output docs: man or markdown")
+	cmd.Flags().StringP("target", "t", "./docs/md", "target directory for output")
+
+	return cmd
+}
+
+func genDocs(cmd *cobra.Command, args []string) error {
+	docFormat, nil := cmd.Flags().GetString("format")
+	targetDir, nil := cmd.Flags().GetString("target")
+
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		Dialog.Errorf(`Failed to create target directory %s: %s`, targetDir, err.Error())
+		return err
+	}
+
+	rootcmd := getCmd()
+
+	if docFormat == "markdown" {
+		doc.GenMarkdownTree(rootcmd, targetDir)
+		Dialog.Infof(`Generated markdown tree in %s`, targetDir)
+	} else if docFormat == "man" {
+		header := &doc.GenManHeader{
+			Title:   "relay",
+			Section: "1",
+		}
+		doc.GenManTree(rootcmd, header, targetDir)
+		Dialog.Infof(`Generated man pages in %s`, targetDir)
+	} else {
+		Dialog.Errorf(`Unknown documentation format %s specified`, docFormat)
+		return nil
+	}
+
+	return nil
+
+}

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -76,6 +76,7 @@ Use the 'workflow' subcommand to interact with workflows:
 
 	cmd.AddCommand(newAuthCommand())
 	cmd.AddCommand(newWorkflowCommand())
+	cmd.AddCommand(newDocCommand())
 
 	return cmd
 }


### PR DESCRIPTION
This adds a `relay doc generate` command that can build
man and markdown format doc trees.

The output format is not ideal; I'd like to have a "real"
manpage that has all the subcommands documented in one page,
and same with the markdown. But it's better than nothing.
The output is meant to be checked into the docs repo or viewed
locally.