### PR TITLE
Batch of renames for nebula->relay production push

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@
 
 Relay is a service that lets you connect tools, APIs, and infrastructure to automate common tasks through simpler, smarter workflows. It links infrastructure events to workflow execution, so that for example, when a new JIRA ticket or Github issue comes in, your workflow can trigger deployments or send notifications.
 
-This repo contains the source for the CLI tool which interacts with the Relay service and also provides the issue tracker for the product as a whole. 
+This repo contains the source for the CLI tool which interacts with the Relay service and also provides the issue tracker for the product as a whole.
 
 ## Installation
 
-Relay evolved from an incubation project at Puppet called Project Nebula, and some of the tooling and documentation still say "Nebula" while we get everything switched over.
-
-You'll need an account on the service to use this tool. [Sign up here](https://puppet.com/products/project-nebula#nebula-form)!
+You'll need an account on the service to use this tool. [Sign up here](https://app.relay.sh/signup). There's a [Getting Started guide](https://relay.sh/docs/getting-started/) to familiarize yourself with Relay concepts.
 
 Once you're up and running, you can install the CLI a couple of different ways:
 
@@ -24,10 +22,10 @@ For other platforms, install directly via Github Releases:
 
 [Get the latest version](https://github.com/puppetlabs/relay/releases)
 
-The program is just a single binary, so you can simply download the one that matches your architecture and copy it to a location in your `$PATH`. Note these binaries are named 'nebula', for the time being simply rename it for consistency:
+The program is just a single binary, so you can simply download the one that matches your architecture and copy it to a location in your `$PATH`.
 
 ```bash
-mv ./nebula-v3.4.0-linux-arm64 /usr/local/bin/relay
+mv ./relay-v4*-linux-arm64 /usr/local/bin/relay
 ```
 
 ## Getting started
@@ -39,7 +37,7 @@ relay login
 relay workflow list
 ```
 
-For more about workflows and further onboarding information, check out the [documentation website](https://puppet.com/docs/nebula/beta/overview.html)
+For more about workflows, check out the [Using Workflows](https://relay.sh/docs/using-workflows/) documentation.
 
 ## Build
 
@@ -50,7 +48,7 @@ To build run
 ./scripts/build
 ```
 
-The resulting binaries will be in `./bin/relay`.
+The resulting binaries will be in `./bin/relay-[version]-[architecture]`.
 
 ## Development
 
@@ -73,4 +71,4 @@ Relay uses [viper](https://github.com/spf13/viper) for customizable config. The 
 
 ## Getting help
 
-If you have questions about Relay, you can [file a github issue](https://github.com/puppetlabs/relay/issues) or join us on the [Puppet community slack](https://slack.puppet.com) in #relay. 
+If you have questions about Relay, you can [file a github issue](https://github.com/puppetlabs/relay/issues) or join us on the [Puppet community slack](https://slack.puppet.com) in #relay.

--- a/build/package/archlinux/PKGBUILD
+++ b/build/package/archlinux/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Kyle Terry <kyle.terry@puppet.com>
 pkgname=puppet-relay
-pkgver=3.4.0
+pkgver=4.1.0
 pkgrel=1
 pkgdesc="CLI for Puppet's Relay workflow service"
 arch=('x86_64')
@@ -13,7 +13,7 @@ sha512sums=('8b57b37675d33852e7d7f6414887c1ce8859b133f1982cc5015755f6e30e38e7da7
 
 build() {
     cd "relay-$pkgver"
-    go build -mod=vendor -o relay ./cmd/nebula
+    go build -mod=vendor -o relay ./cmd/relay
 }
 
 package() {

--- a/build/package/brew/relay-cli-update-brew.yaml
+++ b/build/package/brew/relay-cli-update-brew.yaml
@@ -7,7 +7,7 @@ parameters:
     description: sha256 of the macos binary produced by the release build
 steps:
   - name: clone-and-edit-pr
-    image: projectnebula/core
+    image: relaysh/core:latest
     spec:
       github_token: !Secret github_token
       tag: !Parameter tag
@@ -15,7 +15,7 @@ steps:
       result: "will be overridden by 'ni set' from inside the step"
     inputFile: https://raw.githubusercontent.com/puppetlabs/relay/master/build/package/brew/update_formula.sh
   - name: slack-notify
-    image: projectnebula/slack-notification:latest
+    image: relaysh/slack-step-message-send:latest
     spec:
       apitoken:
         $type: Secret 

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -82,7 +82,7 @@ var mapEncodingTypeToEncoding = map[BodyEncodingType]BodyEncoding{
 type JSONBodyEncoding struct{}
 
 func (j *JSONBodyEncoding) ContentType() string {
-	return fmt.Sprintf("application/vnd.puppet.nebula.%v+json", API_VERSION)
+	return fmt.Sprintf("application/vnd.puppet.relay.%v+json", API_VERSION)
 }
 
 func (j *JSONBodyEncoding) Encode(body interface{}) (io.ReadWriter, errors.Error) {
@@ -101,7 +101,7 @@ func (j *JSONBodyEncoding) Encode(body interface{}) (io.ReadWriter, errors.Error
 type YAMLBodyEncoding struct{}
 
 func (y *YAMLBodyEncoding) ContentType() string {
-	return fmt.Sprintf("application/vnd.puppet.nebula.%v+yaml", API_VERSION)
+	return fmt.Sprintf("application/vnd.puppet.relay.%v+yaml", API_VERSION)
 }
 
 func (y *YAMLBodyEncoding) Encode(body interface{}) (io.ReadWriter, errors.Error) {
@@ -159,7 +159,7 @@ func (c *Client) Request(setters ...RequestOptionSetter) errors.Error {
 	}
 
 	// defaults
-	req.Header.Set("Accept", fmt.Sprintf("application/vnd.puppet.nebula.%v+json", API_VERSION))
+	req.Header.Set("Accept", fmt.Sprintf("application/vnd.puppet.relay.%v+json", API_VERSION))
 
 	if opts.body != nil {
 		req.Header.Set("Content-Type", encoding.ContentType())

--- a/pkg/client/revision.go
+++ b/pkg/client/revision.go
@@ -12,7 +12,7 @@ func (c *Client) CreateRevision(workflowName string, YAML string) (*model.Revisi
 	response := &model.RevisionEntity{}
 
 	var headers = map[string]string{
-		"Content-Type": fmt.Sprintf("application/vnd.puppet.nebula.%v+yaml", API_VERSION),
+		"Content-Type": fmt.Sprintf("application/vnd.puppet.relay.%v+yaml", API_VERSION),
 	}
 
 	if err := c.Request(

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,8 +20,8 @@ const (
 )
 
 const (
-	defaultAPIDomain  = "https://api.nebula.puppet.com"
-	defaultUIDomain   = "https://nebula.puppet.com"
+	defaultAPIDomain  = "https://api.relay.sh"
+	defaultUIDomain   = "https://app.relay.sh"
 	defaultWebDomain  = "https://relay.sh"
 	defaultConfigName = "config"
 	defaultConfigType = "yaml"
@@ -38,7 +38,7 @@ type Config struct {
 	TokenPath string
 }
 
-// Returns a default config set used for error formatting when the user's config set cannot be read
+// GetDefaultConfig returns a config set used for error formatting when the user's config set cannot be read
 func GetDefaultConfig() *Config {
 	// gonna assume that the defaults are valid. Someone can yell at me if they want
 	apiDomain, _ := url.Parse(defaultAPIDomain)


### PR DESCRIPTION
There were a few stray references to nebula in the docs
and internally in the code. This updates the API endpoints
and custom content-type, packaging scripts, and README.