### PR TITLE
Add configuration for worker count

### DIFF
--- a/docs/relay.md
+++ b/docs/relay.md
@@ -35,6 +35,7 @@ Use the 'workflow' subcommand to interact with workflows:
       --image-registry-name string   The name to use on the host and on the cluster nodes for the container image registry (default "docker-registry.docker-registry.svc.cluster.local")
       --image-registry-port int      The port to use on the host and on the cluster nodes for the container image registry (default 5000)
       --load-balancer-port int       The port to map from the host to the service load balancer (default 8080)
+      --worker-count int             The number of worker nodes to create on the cluster (default 2)
 ```
 
 **`relay dev cluster stop`** -- Stop the local cluster

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -12,13 +12,13 @@ import (
 const (
 	ClusterName     = "relay-workflows"
 	NetworkName     = "relay-workflows-net"
-	WorkerCount     = 2
 	HostStorageName = "local-storage"
 
 	DefaultRegistryName         = "docker-registry.docker-registry.svc.cluster.local"
 	DefaultRegistryPort         = 5000
 	DefaultLoadBalancerHostPort = 8080
 	DefaultLoadBalancerNodePort = 80
+	DefaultWorkerCount          = 2
 )
 
 type ClientOptions struct {
@@ -44,6 +44,8 @@ type CreateOptions struct {
 	// `localhost:5000/my-image:latest` and use the same repo/image/tag
 	// combination from k8s resources.
 	ImageRegistryPort int
+	// Number of worker nodes on the cluster
+	WorkerCount int
 }
 
 // Manager provides methods to manage the lifecycle of a cluster.

--- a/pkg/cluster/k3d.go
+++ b/pkg/cluster/k3d.go
@@ -115,11 +115,15 @@ func (m *K3dClusterManager) Create(ctx context.Context, opts CreateOptions) erro
 		Ports:   []string{registryPortMapping},
 	}
 
+	if opts.WorkerCount <= 0 {
+		serverNode.Args = agentArgs
+	}
+
 	nodes := []*types.Node{
 		serverNode,
 	}
 
-	for i := 0; i < WorkerCount; i++ {
+	for i := 0; i < opts.WorkerCount; i++ {
 		node := &types.Node{
 			Role:    types.AgentRole,
 			Image:   k3sImage,

--- a/pkg/cmd/cluster.go
+++ b/pkg/cmd/cluster.go
@@ -30,6 +30,7 @@ func newStartClusterCommand() *cobra.Command {
 	cmd.Flags().IntP("load-balancer-port", "", cluster.DefaultLoadBalancerHostPort, "The port to map from the host to the service load balancer")
 	cmd.Flags().StringP("image-registry-name", "", cluster.DefaultRegistryName, "The name to use on the host and on the cluster nodes for the container image registry")
 	cmd.Flags().IntP("image-registry-port", "", cluster.DefaultRegistryPort, "The port to use on the host and on the cluster nodes for the container image registry")
+	cmd.Flags().IntP("worker-count", "", cluster.DefaultWorkerCount, "The number of worker nodes to create on the cluster")
 
 	return cmd
 }
@@ -52,6 +53,11 @@ func doStartCluster(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	workerCount, err := cmd.Flags().GetInt("worker-count")
+	if err != nil {
+		return err
+	}
+
 	cm := cluster.NewManager(ClusterConfig)
 
 	if _, err := cm.Exists(ctx); err != nil {
@@ -60,6 +66,7 @@ func doStartCluster(cmd *cobra.Command, args []string) error {
 			LoadBalancerHostPort: lbHostPort,
 			ImageRegistryName:    registryName,
 			ImageRegistryPort:    registryPort,
+			WorkerCount:          workerCount,
 		}
 		if err := cm.Create(ctx, opts); err != nil {
 			return err


### PR DESCRIPTION
Allows the number of worker nodes to be configured, rather than the previously hardcoded value of 2.
Default number of worker nodes remains 2.
Setting this value to 0 will apply the appropriate labels to the server node to support a fully functional single node.

Configuration option naming could stand to be more clear...
