### PR TITLE
Fix parameter type

### DIFF
--- a/pkg/model/revision.go
+++ b/pkg/model/revision.go
@@ -31,8 +31,8 @@ type RevisionEntity struct {
 type WorkflowParameters map[string]WorkflowParameter
 
 type WorkflowParameter struct {
-	Default     string `json:"default"`
-	Description string `json:"description,omitempty"`
+	Default     interface{} `json:"default"`
+	Description string      `json:"description,omitempty"`
 }
 
 type WorkflowTrigger struct {


### PR DESCRIPTION
The parameter type (for the default value) is currently inconsistent with the rest of the system. This currently prevents downloading, adding, or replacing a workflow if anything other than a string is used for parameters (bool, int, etc.).