### PR TITLE
Do not automatically delete workflow on error

### DIFF
--- a/pkg/cmd/workflow.go
+++ b/pkg/cmd/workflow.go
@@ -57,10 +57,6 @@ func doAddWorkflow(cmd *cobra.Command, args []string) error {
 	revision, rerr := Client.CreateRevision(workflow.Workflow.Name, file)
 
 	if rerr != nil {
-
-		// attempt to revert creation of workflow record
-		Client.DeleteWorkflow(workflow.Workflow.Name)
-
 		return rerr
 	}
 
@@ -69,7 +65,7 @@ func doAddWorkflow(cmd *cobra.Command, args []string) error {
 	wr.Output(Config)
 
 	Dialog.Infof(`Successfully created workflow %v
-			
+
 View more information or update workflow settings at: %v`,
 		workflow.Workflow.Name,
 		format.GuiLink(Config, "/workflows/%v", workflow.Workflow.Name),
@@ -123,7 +119,7 @@ func doReplaceWorkflow(cmd *cobra.Command, args []string) error {
 	wr.Output(Config)
 
 	Dialog.Infof(`Successfully updated workflow %v
-			
+
 Updated version is visible at: %v`,
 		workflowName,
 		format.GuiLink(Config, "/workflows/%v", workflowName),


### PR DESCRIPTION
Avoid deleting the workflow if creating the revision fails.

By far, the most common reasons for errors during revision processing are validation errors.
This shouldn't result in deletion of the workflow.

In the future, as we improve our validation, this could potentially provide more helpful commentary/instructions regarding fixing the workflow file and replacing the file.

Even then, deleting the workflow for any other reason would and should never be done automatically here. A destructive act of that nature could only be considered as an optional flag that has to be explicitly set.
