### PR TITLE
Update messaging when no workflow file/data is found

### DIFF
--- a/pkg/cmd/workflow.go
+++ b/pkg/cmd/workflow.go
@@ -302,7 +302,7 @@ func doDownloadWorkflow(cmd *cobra.Command, args []string) error {
 
 	if err != nil {
 		if errors.IsClientResponseNotFound(err) {
-			Dialog.Infof(`No file data found for workflow %v
+			Dialog.Warnf(`No file data found for workflow %v
 
 View more information or update workflow settings at: %v`,
 				name,

--- a/pkg/cmd/workflow.go
+++ b/pkg/cmd/workflow.go
@@ -301,6 +301,16 @@ func doDownloadWorkflow(cmd *cobra.Command, args []string) error {
 	body, err := Client.DownloadWorkflow(name)
 
 	if err != nil {
+		if errors.IsClientResponseNotFound(err) {
+			Dialog.Infof(`No file data found for workflow %v
+
+View more information or update workflow settings at: %v`,
+				name,
+				format.GuiLink(Config, "/workflows/%v", name),
+			)
+
+			return nil
+		}
 		return err
 	}
 

--- a/pkg/dialog/dialog.go
+++ b/pkg/dialog/dialog.go
@@ -24,6 +24,9 @@ type Dialog interface {
 	Info(string)
 	Infof(string, ...interface{})
 
+	Warn(string)
+	Warnf(string, ...interface{})
+
 	Error(string)
 	Errorf(string, ...interface{})
 
@@ -78,6 +81,19 @@ func (d *TextDialog) Infof(message string, args ...interface{}) {
 	fmt.Fprintf(d.stdout, withNewLine(message), args...)
 }
 
+func (d *TextDialog) Warn(msg string) {
+	d.completeProgress()
+
+	fmt.Fprintf(d.stderr, "%s %s", color.YellowString("Warning:"), withNewLine(msg))
+}
+
+func (d *TextDialog) Warnf(msg string, args ...interface{}) {
+	d.completeProgress()
+
+	str := fmt.Sprintf(msg, args...)
+	fmt.Fprintf(d.stderr, "%s %s", color.YellowString("Warning:"), withNewLine(str))
+}
+
 func (d *TextDialog) Error(msg string) {
 	d.completeProgress()
 
@@ -129,6 +145,15 @@ func (d *JSONDialog) Info(message string) {
 
 func (d *JSONDialog) Infof(message string, args ...interface{}) {
 	// noop
+}
+
+func (d *JSONDialog) Warn(msg string) {
+	fmt.Fprintf(d.stderr, "%s%s", color.YellowString("Warning:"), msg)
+}
+
+func (d *JSONDialog) Warnf(msg string, args ...interface{}) {
+	str := fmt.Sprintf(msg, args...)
+	fmt.Fprintf(d.stderr, "%s%s", color.YellowString("Warning:"), str)
 }
 
 func (d *JSONDialog) Error(msg string) {


### PR DESCRIPTION
Add more user-friendly messaging when no file data is found for a workflow.
The error we're returning in this situation is a bit vague and we should perhaps be clarified.

"No file data found" is also debatable language, but I think it tracks with the current terminology used.