### PR TITLE
Add token handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,12 @@ go run ./cmd/relay
 
 Relay uses [viper](https://github.com/spf13/viper) for customizable config. The following config values may be set in a yaml file at `$HOME/.config/relay/config.yaml` or as environment variables with corresponding names in all caps, prefixed with `RELAY_`:
 
-- `debug`: Run relay in debug mode. Overriden by global `--debug` flag.
-- `out=(text|json)`: Output mode. Overriden by global `--out` flag.
-- `api_domain`: Relay api domain to connect to for all api operations.
-- `ui_domain`: Relay ui domain, mainly used in generated links.
+- `debug`: Run Relay in debug mode. Overridden by global `--debug` flag.
+- `out=(text|json)`: Output mode. Overridden by global `--out` flag.
+- `api_domain`: Relay API domain to connect to for all API operations.
+- `ui_domain`: Relay UI domain, mainly used in generated links.
 - `web_domain`: Relay web domain, mainly used in generated links.
 - `cache_dir`: Cache directory.
-- `token_path`: Path to token storage location.
 
 ## Getting help
 

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -19,11 +19,21 @@ Use the 'workflow' subcommand to interact with workflows:
 
 ### Subcommand Usage
 
-**`relay auth login`** -- Log in to Relay
+**`relay auth login [flags]`** -- Log in to Relay
+```
+  -f, --file string   Read authentication credentials from file
+      --stdin         Read authentication credentials from stdin
+```
 
 **`relay auth logout`** -- Log out of Relay
 
 **`relay completion`** -- Generate shell completion scripts
+
+**`relay config auth clear`** -- Clear the stored authentication for the current context
+
+**`relay context set [context name]`** -- Set current context
+
+**`relay context view`** -- View current context
 
 **`relay dev cluster create [flags]`** -- Create the local cluster
 ```
@@ -87,6 +97,19 @@ you can query repeatedly.
 
 **`relay subscriptions unsubscribe [workflow name]`** -- Unsubscribe to workflow
 
+**`relay tokens create [token name] [flags]`** -- Create API token
+```
+  -f, --file string   Write the generated token to the supplied file
+  -u, --use           Configure the CLI to use the generated API token (default true)
+```
+
+**`relay tokens list [flags]`** -- List API tokens
+```
+  -a, --all   Show all account tokens
+```
+
+**`relay tokens revoke [token id]`** -- Revoke API token
+
 **`relay workflow add [workflow name] [flags]`** -- Add a Relay workflow from a local file
 ```
   -f, --file string   Path to Relay workflow file
@@ -96,7 +119,7 @@ you can query repeatedly.
 
 **`relay workflow download [workflow name] [flags]`** -- Download a workflow from the service
 ```
-  -f, --file string   Filename to write workflow, relative to current working dir
+  -f, --file string   Path to write workflow file
 ```
 
 **`relay workflow list`** -- Get a list of all your workflows
@@ -127,8 +150,10 @@ you can query repeatedly.
 
 ### Global flags
 ```
-  -d, --debug        print debugging information
-  -o, --out string   output type: (text|json) (default "text")
-  -y, --yes          skip confirmation prompts
+  -x, --context string   Override the current context
+  -d, --debug            Print debugging information
+  -h, --help             Show help for this command
+  -o, --out string       Output type: (text|json) (default "text")
+  -y, --yes              Skip confirmation prompts
 
 ```

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -29,7 +29,10 @@ Use the 'workflow' subcommand to interact with workflows:
 
 **`relay completion`** -- Generate shell completion scripts
 
-**`relay config auth clear`** -- Clear the stored authentication for the current context
+**`relay config auth clear [flags]`** -- Clear stored authentication data for the current context
+```
+  -t, --type string   Authentication type (api|session)
+```
 
 **`relay context set [context name]`** -- Set current context
 

--- a/pkg/client/auth.go
+++ b/pkg/client/auth.go
@@ -17,6 +17,7 @@ type createTokenResponse struct {
 }
 
 type UserDeviceValues struct {
+	Token                   *model.Token
 	UserCode                string
 	VerificationURI         string
 	VerificationURIComplete string
@@ -32,11 +33,8 @@ func (c *Client) CreateToken() (*UserDeviceValues, errors.Error) {
 		return nil, err
 	}
 
-	if err := c.storeToken(response.Token); err != nil {
-		return nil, errors.NewClientInternalError().WithCause(err)
-	}
-
 	return &UserDeviceValues{
+		Token:                   response.Token,
 		UserCode:                response.UserCode,
 		VerificationURI:         response.VerificationURI,
 		VerificationURIComplete: response.VerificationURIComplete,
@@ -50,7 +48,7 @@ func (c *Client) InvalidateToken() errors.Error {
 
 	dr := &deleteResponse{}
 
-	// Dont propagate error: if existing token is invalid endpoint will 401. Not sure this is
+	// Don't propagate error: if existing token is invalid endpoint will 401. Not sure this is
 	// good behavior but it's true nonetheless
 	c.Request(
 		WithMethod(http.MethodDelete),

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -20,8 +20,15 @@ type Client struct {
 
 func NewClient(config *config.Config) *Client {
 	cc := openapi.NewConfiguration()
-	cc.Host = config.ContextConfig.APIDomain.Host
-	cc.Scheme = config.ContextConfig.APIDomain.Scheme
+	if config.ContextConfig != nil {
+		context := config.CurrentContext
+		if contextConfig, ok := config.ContextConfig[context]; ok {
+			if contextConfig.Domains != nil {
+				cc.Host = contextConfig.Domains.APIDomain.Host
+				cc.Scheme = contextConfig.Domains.APIDomain.Scheme
+			}
+		}
+	}
 	cc.Debug = false
 
 	api := openapi.NewAPIClient(cc)

--- a/pkg/client/openapi/configuration.go
+++ b/pkg/client/openapi/configuration.go
@@ -105,7 +105,7 @@ func NewConfiguration() *Configuration {
 		Debug:            false,
 		Servers:          ServerConfigurations{
 			{
-				URL: "",
+				URL: "https://api.relay.sh",
 				Description: "No description provided",
 			},
 		},

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -135,8 +135,13 @@ func (c *Client) Request(setters ...RequestOptionSetter) errors.Error {
 		setter(opts)
 	}
 
+	contextConfig, ok := c.config.ContextConfig[c.config.CurrentContext]
+	if !ok {
+		return errors.NewClientInternalError()
+	}
+
 	rel := &url.URL{Path: opts.path}
-	u := c.config.ContextConfig.APIDomain.ResolveReference(rel)
+	u := contextConfig.Domains.APIDomain.ResolveReference(rel)
 
 	encoding, ok := mapEncodingTypeToEncoding[opts.BodyEncodingType]
 

--- a/pkg/client/token.go
+++ b/pkg/client/token.go
@@ -1,70 +1,35 @@
 package client
 
 import (
-	"bytes"
-	"os"
-	"path/filepath"
-
+	"github.com/puppetlabs/relay/pkg/config"
 	"github.com/puppetlabs/relay/pkg/model"
 )
 
 // getToken reads token from client cache or from path specified on config
 func (c *Client) getToken() (*model.Token, error) {
 	if c.loadedToken == nil {
-		f, err := os.Open(c.config.TokenPath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil, nil
+		if c.config.ContextConfig != nil {
+			context := c.config.CurrentContext
+
+			if contextConfig, ok := c.config.ContextConfig[context]; ok {
+				if contextConfig.Auth != nil && contextConfig.Auth.Tokens != nil {
+					for _, tokenType := range []config.AuthTokenType{config.AuthTokenTypeAPI, config.AuthTokenTypeSession} {
+						if value, ok := contextConfig.Auth.Tokens[tokenType]; ok && value != "" {
+							token := model.Token(value)
+							c.loadedToken = &token
+							return c.loadedToken, nil
+						}
+					}
+				}
 			}
-
-			return nil, err
 		}
-
-		defer f.Close()
-
-		buf := &bytes.Buffer{}
-		if _, err := buf.ReadFrom(f); err != nil {
-			return nil, err
-		}
-
-		token := model.Token(buf.String())
-
-		c.loadedToken = &token
-
-		return &token, nil
 	}
 
 	return c.loadedToken, nil
 }
 
-// storeToken Saves token to the token storage location specified by config,
-// creating directories as needed
-func (c *Client) storeToken(token *model.Token) error {
-	if err := os.MkdirAll(filepath.Dir(c.config.TokenPath), 0750); err != nil {
-		return err
-	}
-
-	f, err := os.OpenFile(c.config.TokenPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0750)
-	if err != nil {
-		return err
-	}
-
-	defer f.Close()
-
-	if _, err := f.Write([]byte(token.String())); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// clearToken removes token from local storage and from loadedToken cache on client object.
-// It does not error if the token does not exist.
+// ClearToken clears the token from the loadedToken cache on client object.
 func (c *Client) clearToken() error {
-	if err := os.Remove(c.config.TokenPath); err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
 	c.loadedToken = nil
 
 	return nil

--- a/pkg/client/token.go
+++ b/pkg/client/token.go
@@ -13,7 +13,7 @@ func (c *Client) getToken() (*model.Token, error) {
 
 			if contextConfig, ok := c.config.ContextConfig[context]; ok {
 				if contextConfig.Auth != nil && contextConfig.Auth.Tokens != nil {
-					for _, tokenType := range []config.AuthTokenType{config.AuthTokenTypeAPI, config.AuthTokenTypeSession} {
+					for _, tokenType := range config.AuthTokenTypes() {
 						if value, ok := contextConfig.Auth.Tokens[tokenType]; ok && value != "" {
 							token := model.Token(value)
 							c.loadedToken = &token
@@ -28,7 +28,7 @@ func (c *Client) getToken() (*model.Token, error) {
 	return c.loadedToken, nil
 }
 
-// ClearToken clears the token from the loadedToken cache on client object.
+// clearToken clears the token from the loadedToken cache on client object.
 func (c *Client) clearToken() error {
 	c.loadedToken = nil
 

--- a/pkg/cmd/auth.go
+++ b/pkg/cmd/auth.go
@@ -180,7 +180,7 @@ func writeAuthTokenConfig(cmd *cobra.Command, token string, tokenType config.Aut
 				Config.CurrentContext: {
 					Auth: &config.AuthConfig{
 						Tokens: map[config.AuthTokenType]string{
-							tokenType: token,
+							tokenType: strings.TrimSpace(token),
 						},
 					},
 				},

--- a/pkg/cmd/auth.go
+++ b/pkg/cmd/auth.go
@@ -2,11 +2,14 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
 	"strings"
 
 	"github.com/cli/browser"
 	"github.com/eiannone/keyboard"
+	"github.com/puppetlabs/relay/pkg/config"
 	"github.com/puppetlabs/relay/pkg/errors"
+	"github.com/puppetlabs/relay/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -26,13 +29,14 @@ func newAuthCommand() *cobra.Command {
 	return cmd
 }
 
-func doLogin(cmd *cobra.Command, args []string) error {
-	Dialog.Progress("Getting authorization...")
-
+func negotiateSession(cmd *cobra.Command) error {
 	deviceValues, cterr := Client.CreateToken()
 	if cterr != nil {
 		return cterr
 	}
+
+	writeAuthTokenConfig(cmd, deviceValues.Token.String(), config.AuthTokenTypeSession)
+
 	Dialog.Info("Stored authorization token.")
 
 	Dialog.Info(fmt.Sprintf(
@@ -69,6 +73,64 @@ Press [ENTER] to open %s in a browser or any other key to cancel...`,
 		return errors.NewAuthFailedLoginError().WithCause(fmt.Errorf("error opening the web browser: %w", err))
 	}
 
+	return nil
+}
+
+func readAuthFromStdin(cmd *cobra.Command) error {
+	gotStdin, err := util.PassedStdin()
+	if err != nil {
+		return err
+	}
+
+	if gotStdin {
+		token, err := util.ReadStdin(readLimit)
+		if err != nil {
+			return err
+		}
+
+		writeAuthTokenConfig(cmd, string(token), config.AuthTokenTypeAPI)
+	}
+
+	return nil
+}
+func doLogin(cmd *cobra.Command, args []string) error {
+	Dialog.Progress("Getting authorization...")
+
+	stdin, err := cmd.Flags().GetBool("stdin")
+	if err != nil {
+		return err
+	}
+
+	if stdin {
+		err = readAuthFromStdin(cmd)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	file, err := cmd.Flags().GetString("file")
+	if err != nil {
+		return nil
+	}
+
+	if file != "" {
+		token, err := ioutil.ReadFile(file)
+		if err != nil {
+			return nil
+		}
+
+		writeAuthTokenConfig(cmd, string(token), config.AuthTokenTypeAPI)
+
+		return nil
+	}
+
+	err = negotiateSession(cmd)
+	if err != nil {
+		return err
+	}
+
 	Dialog.Info("Done!")
 	return nil
 }
@@ -80,6 +142,9 @@ func newLoginCommand() *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		RunE:  doLogin,
 	}
+
+	cmd.Flags().StringP("file", "f", "", "Read authentication credentials from file")
+	cmd.Flags().Bool("stdin", false, "Read authentication credentials from stdin")
 
 	return cmd
 }
@@ -106,4 +171,22 @@ func newLogoutCommand() *cobra.Command {
 	}
 
 	return cmd
+}
+
+func writeAuthTokenConfig(cmd *cobra.Command, token string, tokenType config.AuthTokenType) {
+	if len(token) > 0 {
+		cfg := &config.Config{
+			ContextConfig: map[string]*config.ContextConfig{
+				Config.CurrentContext: {
+					Auth: &config.AuthConfig{
+						Tokens: map[config.AuthTokenType]string{
+							tokenType: token,
+						},
+					},
+				},
+			},
+		}
+
+		config.WriteConfig(cfg, cmd.Flags())
+	}
 }

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"github.com/puppetlabs/relay/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+func newConfigCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Manage Relay CLI configuration",
+		Args:  cobra.ExactArgs(0),
+	}
+
+	cmd.AddCommand(newConfigAuthCommand())
+
+	return cmd
+}
+
+func newConfigAuthCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Manage Relay CLI authentication configuration",
+		Args:  cobra.ExactArgs(0),
+	}
+
+	cmd.AddCommand(newConfigAuthClearCommand())
+
+	return cmd
+}
+
+func newConfigAuthClearCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "clear",
+		Short: "Clear the stored authentication for the current context",
+		Args:  cobra.ExactArgs(0),
+		RunE:  doConfigAuthClear,
+	}
+
+	return cmd
+}
+
+func doConfigAuthClear(cmd *cobra.Command, args []string) error {
+	cfg := &config.Config{
+		ContextConfig: map[string]*config.ContextConfig{
+			Config.CurrentContext: {
+				Auth: &config.AuthConfig{
+					Tokens: map[config.AuthTokenType]string{
+						config.AuthTokenTypeAPI:     "",
+						config.AuthTokenTypeSession: "",
+					},
+				},
+			},
+		},
+	}
+
+	config.WriteConfig(cfg, cmd.Flags())
+
+	return nil
+}

--- a/pkg/cmd/context.go
+++ b/pkg/cmd/context.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"github.com/puppetlabs/relay/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+func newContextCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "context",
+		Short: "Manage Relay context",
+		Args:  cobra.ExactArgs(0),
+	}
+
+	cmd.AddCommand(newSetContext())
+	cmd.AddCommand(newViewContext())
+
+	return cmd
+}
+
+func newSetContext() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set [context name]",
+		Short: "Set current context",
+		Args:  cobra.ExactArgs(1),
+		RunE:  doSetContext,
+	}
+
+	return cmd
+}
+
+func newViewContext() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "view",
+		Short: "View current context",
+		Args:  cobra.ExactArgs(0),
+		RunE:  doViewContext,
+	}
+
+	return cmd
+}
+
+func doSetContext(cmd *cobra.Command, args []string) error {
+	cfg := &config.Config{
+		CurrentContext: args[0],
+	}
+
+	config.WriteConfig(cfg, cmd.Flags())
+
+	return nil
+}
+
+func doViewContext(cmd *cobra.Command, args []string) error {
+	context := Config.CurrentContext
+	Dialog.Infof("Context: %s", context)
+
+	if contextConfig, ok := Config.ContextConfig[context]; ok {
+		Dialog.Infof("API Domain: %s", contextConfig.Domains.APIDomain)
+		Dialog.Infof("UI Domain: %s", contextConfig.Domains.UIDomain)
+	} else {
+		Dialog.Info("No context configuration found")
+	}
+
+	return nil
+}

--- a/pkg/cmd/kubectl.go
+++ b/pkg/cmd/kubectl.go
@@ -22,8 +22,14 @@ func newKubectlCommand() *cobra.Command {
 
 func doRunKubectl(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
+
 	cm := cluster.NewManager(ClusterConfig)
+
 	cl, err := cm.GetClient(ctx, cluster.ClientOptions{Scheme: dev.DefaultScheme})
+	if err != nil {
+		return err
+	}
+
 	dm := dev.NewManager(cm, cl, DevConfig)
 
 	newcmd, err := dm.KubectlCommand()

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -67,24 +67,27 @@ Use the 'workflow' subcommand to interact with workflows:
 		},
 	}
 
-	cmd.PersistentFlags().BoolVarP(&debug.Enabled, "debug", "d", false, "print debugging information")
-	cmd.PersistentFlags().BoolP("yes", "y", false, "skip confirmation prompts")
-	cmd.PersistentFlags().StringP("out", "o", "text", "output type: (text|json)")
+	cmd.PersistentFlags().StringP("context", "x", "", "Override the current context")
+	cmd.PersistentFlags().BoolVarP(&debug.Enabled, "debug", "d", false, "Print debugging information")
+	cmd.PersistentFlags().BoolP("help", "h", false, "Show help for this command")
+	cmd.PersistentFlags().BoolP("yes", "y", false, "Skip confirmation prompts")
+	cmd.PersistentFlags().StringP("out", "o", "text", "Output type: (text|json)")
 
 	// allow the user to override the default configuration location if they
 	// can find the flag. likely figured out from reading this comment, actually...
-	cmd.PersistentFlags().StringP("config", "c", "", "path to config file (default is $HOME.config/relay)")
+	cmd.PersistentFlags().StringP("config", "c", "", "Path to config file (default is $HOME.config/relay)")
 	cmd.PersistentFlags().MarkHidden("config")
-	cmd.PersistentFlags().StringP("context", "x", "", "current context")
-	cmd.PersistentFlags().MarkHidden("context")
 
 	cmd.AddCommand(newAuthCommand())
+	cmd.AddCommand(newConfigCommand())
+	cmd.AddCommand(newContextCommand())
 	cmd.AddCommand(newWorkflowCommand())
 	cmd.AddCommand(newDevCommand())
 	cmd.AddCommand(newDocCommand())
 	cmd.AddCommand(newCompletionCommand())
 	cmd.AddCommand(newNotificationsCommand())
 	cmd.AddCommand(newSubscriptionsCommand())
+	cmd.AddCommand(newTokensCommand())
 
 	return cmd
 }

--- a/pkg/cmd/token.go
+++ b/pkg/cmd/token.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"errors"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/puppetlabs/relay/pkg/client/openapi"
+	"github.com/puppetlabs/relay/pkg/config"
+	"github.com/puppetlabs/relay/pkg/debug"
+	"github.com/spf13/cobra"
+)
+
+func newTokensCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tokens",
+		Short: "Manage API tokens",
+		Args:  cobra.MinimumNArgs(1),
+	}
+
+	cmd.AddCommand(newCreateToken())
+	cmd.AddCommand(newListTokens())
+	cmd.AddCommand(newRevokeToken())
+
+	return cmd
+}
+
+func newCreateToken() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create [token name]",
+		Short: "Create API token",
+		Args:  cobra.MinimumNArgs(1),
+		RunE:  doCreateToken,
+	}
+
+	cmd.Flags().BoolP("use", "u", true, "Configure the CLI to use the generated API token")
+	cmd.Flags().StringP("file", "f", "", "Write the generated token to the supplied file")
+
+	return cmd
+}
+
+func newRevokeToken() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "revoke [token id]",
+		Short: "Revoke API token",
+		Args:  cobra.MinimumNArgs(1),
+		RunE:  doRevokeToken,
+	}
+
+	return cmd
+}
+
+func newListTokens() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List API tokens",
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  doListTokens,
+	}
+
+	cmd.Flags().BoolP("all", "a", false, "Show all account tokens")
+
+	return cmd
+}
+
+func doCreateToken(cmd *cobra.Command, args []string) error {
+	Dialog.Progress("Creating token...")
+
+	req := Client.Api.TokensApi.CreateToken(cmd.Context())
+	t, resp, err := Client.Api.TokensApi.CreateTokenExecute(
+		req.TokenRequest(openapi.TokenRequest{
+			Name: args[0],
+			Type: "user",
+		}),
+	)
+
+	if err != nil {
+		switch resp.StatusCode {
+		case http.StatusConflict:
+			return errors.New("A token by that name already exists")
+		default:
+			return err
+		}
+	}
+
+	if token, ok := t.GetTokenOk(); ok {
+		secret := token.UserTokenWithSecret.GetSecret()
+		filepath, err := cmd.Flags().GetString("file")
+		if err != nil {
+			return err
+		}
+
+		if filepath != "" {
+			if err := ioutil.WriteFile(filepath, []byte(secret), 0644); err != nil {
+				debug.Logf("failed to write to file %s: %s", filepath, err.Error())
+				return err
+			}
+		}
+
+		use, err := cmd.Flags().GetBool("use")
+		if err != nil {
+			return err
+		}
+
+		if use {
+			writeAuthTokenConfig(cmd, *token.UserTokenWithSecret.Secret, config.AuthTokenTypeAPI)
+		}
+	}
+
+	return nil
+}
+
+func doRevokeToken(cmd *cobra.Command, args []string) error {
+	Dialog.Progress("Revoking token...")
+
+	req := Client.Api.TokensApi.DeleteToken(cmd.Context(), args[0])
+	_, _, err := Client.Api.TokensApi.DeleteTokenExecute(req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func doListTokens(cmd *cobra.Command, args []string) error {
+	Dialog.Progress("Listing tokens...")
+
+	all, err := cmd.Flags().GetBool("all")
+	if err != nil {
+		return err
+	}
+
+	req := Client.Api.TokensApi.GetTokens(cmd.Context())
+	t, _, err := Client.Api.TokensApi.GetTokensExecute(req.Owned(!all).Valid(true))
+	if err != nil {
+		return err
+	}
+
+	if tokens, ok := t.GetTokensOk(); ok {
+		t := Dialog.Table()
+
+		t.Headers([]string{"User", "Id", "Name", "Type"})
+
+		for _, token := range *tokens {
+			t.AppendRow([]string{token.UserToken.GetUser().Name, token.UserToken.GetId(), token.UserToken.GetName(), token.UserToken.GetType()})
+		}
+
+		t.Flush()
+	}
+
+	return nil
+}

--- a/pkg/cmd/workflow.go
+++ b/pkg/cmd/workflow.go
@@ -319,7 +319,10 @@ View more information or update workflow settings at: %v`,
 		return err
 	}
 
-	filepath, nil := cmd.Flags().GetString("file")
+	filepath, ferr := cmd.Flags().GetString("file")
+	if ferr != nil {
+		return ferr
+	}
 
 	if filepath == "" {
 		Dialog.WriteString(body)
@@ -341,7 +344,7 @@ func newDownloadWorkflowCommand() *cobra.Command {
 		RunE:  doDownloadWorkflow,
 	}
 
-	cmd.Flags().StringP("file", "f", "", "Filename to write workflow, relative to current working dir")
+	cmd.Flags().StringP("file", "f", "", "Path to write workflow file")
 
 	return cmd
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,24 +20,41 @@ const (
 	OutputTypeJSON OutputType = "json"
 )
 
+type AuthTokenType string
+
 const (
+	AuthTokenTypeAPI     AuthTokenType = "api"
+	AuthTokenTypeSession AuthTokenType = "session"
+)
+
+func (att AuthTokenType) String() string {
+	return string(att)
+}
+
+const (
+	RelayEnvironment = "relay"
+
 	defaultConfigName     = "config"
 	defaultConfigType     = "yaml"
 	defaultCurrentContext = "relaysh"
 )
 
-var defaultContexts = map[string]APIContext{
+var defaultContexts = map[string]*ContextConfig{
 	"relaysh": {
-		Name:      "relaysh",
-		APIDomain: &url.URL{Scheme: "https", Host: "api.relay.sh"},
-		UIDomain:  &url.URL{Scheme: "https", Host: "app.relay.sh"},
-		WebDomain: &url.URL{Scheme: "https", Host: "relay.sh"},
+		Domains: &APIContext{
+			Name:      "relaysh",
+			APIDomain: &url.URL{Scheme: "https", Host: "api.relay.sh"},
+			UIDomain:  &url.URL{Scheme: "https", Host: "app.relay.sh"},
+			WebDomain: &url.URL{Scheme: "https", Host: "relay.sh"},
+		},
 	},
 	"dev": {
-		Name:      "dev",
-		APIDomain: &url.URL{Scheme: "http", Host: "relay-api.local:8080"},
-		UIDomain:  &url.URL{Scheme: "http", Host: "relay-ui.local:8080"},
-		WebDomain: &url.URL{Scheme: "http", Host: "relay-ui.local:8080"},
+		Domains: &APIContext{
+			Name:      "dev",
+			APIDomain: &url.URL{Scheme: "http", Host: "relay-api.local:8080"},
+			UIDomain:  &url.URL{Scheme: "http", Host: "relay-ui.local:8080"},
+			WebDomain: &url.URL{Scheme: "http", Host: "relay-ui.local:8080"},
+		},
 	},
 }
 
@@ -55,6 +72,15 @@ type LogServiceConfig struct {
 	Table                 string
 }
 
+type AuthConfig struct {
+	Tokens map[AuthTokenType]string
+}
+
+type ContextConfig struct {
+	Auth    *AuthConfig
+	Domains *APIContext
+}
+
 type Config struct {
 	Debug          bool
 	Yes            bool
@@ -63,7 +89,7 @@ type Config struct {
 	TokenPath      string
 	CurrentContext string
 
-	ContextConfig *APIContext
+	ContextConfig map[string]*ContextConfig
 
 	LogServiceConfig *LogServiceConfig
 }
@@ -75,14 +101,9 @@ func GetDefaultConfig() *Config {
 		Yes:            false,
 		Out:            OutputTypeText,
 		CacheDir:       userCacheDir(),
-		TokenPath:      filepath.Join(userCacheDir(), "auth-token"),
 		CurrentContext: defaultCurrentContext,
 
-		ContextConfig: &APIContext{
-			APIDomain: defaultContexts[defaultCurrentContext].APIDomain,
-			UIDomain:  defaultContexts[defaultCurrentContext].UIDomain,
-			WebDomain: defaultContexts[defaultCurrentContext].WebDomain,
-		},
+		ContextConfig: defaultContexts,
 	}
 }
 
@@ -123,7 +144,7 @@ func NewLogServiceConfig(v *viper.Viper) *LogServiceConfig {
 func FromFlags(flags *pflag.FlagSet) (*Config, error) {
 	v := viper.New()
 
-	v.SetEnvPrefix("relay")
+	v.SetEnvPrefix(RelayEnvironment)
 	v.AutomaticEnv()
 
 	v.SetDefault("debug", false)
@@ -137,16 +158,15 @@ func FromFlags(flags *pflag.FlagSet) (*Config, error) {
 
 	v.SetDefault("cache_dir", userCacheDir())
 	v.SetDefault("data_dir", userDataDir())
-	v.SetDefault("token_path", filepath.Join(userCacheDir(), "auth-token"))
 
-	v.SetDefault("current_context", defaultCurrentContext)
-	v.BindPFlag("current_context", flags.Lookup("context"))
+	v.SetDefault("context", defaultCurrentContext)
+	v.BindPFlag("context", flags.Lookup("context"))
 
 	if err := readInConfigFile(v, flags); err != nil {
 		return nil, err
 	}
 
-	context := v.GetString("current_context")
+	context := v.GetString("context")
 
 	output, err := readOutput(v)
 	if err != nil {
@@ -154,11 +174,11 @@ func FromFlags(flags *pflag.FlagSet) (*Config, error) {
 	}
 
 	config := &Config{
-		Debug:          v.GetBool("debug"),
-		Yes:            v.GetBool("yes"),
-		Out:            output,
-		CacheDir:       v.GetString("cache_dir"),
-		TokenPath:      v.GetString("token_path"),
+		Debug:    v.GetBool("debug"),
+		Yes:      v.GetBool("yes"),
+		Out:      output,
+		CacheDir: v.GetString("cache_dir"),
+
 		CurrentContext: context,
 	}
 
@@ -173,44 +193,96 @@ func FromFlags(flags *pflag.FlagSet) (*Config, error) {
 
 		contextSection := v.Sub(fmt.Sprintf("contexts.%s", context))
 		if contextSection != nil {
-			contextConfig, err := NewAPIContext(contextSection)
+			domainConfig, err := NewAPIContext(contextSection)
 			if err != nil {
 				return nil, err
 			}
 
-			config.ContextConfig = contextConfig
+			config.ContextConfig = map[string]*ContextConfig{
+				context: {
+					Domains: domainConfig,
+				},
+			}
+
+			authSection := contextSection.Sub("auth")
+			if authSection != nil {
+				config.ContextConfig[context].Auth = &AuthConfig{
+					Tokens: make(map[AuthTokenType]string),
+				}
+
+				for _, tokenType := range []AuthTokenType{AuthTokenTypeAPI, AuthTokenTypeSession} {
+					token := authSection.GetString(fmt.Sprintf("tokens.%s", tokenType))
+					config.ContextConfig[context].Auth.Tokens[tokenType] = token
+				}
+			}
 		}
 	}
 
 	// Deprecated. Backwards compatibility only.
 	if config.ContextConfig == nil {
-		v.SetDefault("api_domain", defaultContexts[context].APIDomain)
-		v.SetDefault("ui_domain", defaultContexts[context].UIDomain)
-		v.SetDefault("web_domain", defaultContexts[context].WebDomain)
+		if _, ok := defaultContexts[context]; ok {
+			v.SetDefault("api_domain", defaultContexts[context].Domains.APIDomain)
+			v.SetDefault("ui_domain", defaultContexts[context].Domains.UIDomain)
+			v.SetDefault("web_domain", defaultContexts[context].Domains.WebDomain)
 
-		apiDomain, err := readAPIDomain(v)
-		if err != nil {
-			return nil, err
-		}
+			apiDomain, err := readAPIDomain(v)
+			if err != nil {
+				return nil, err
+			}
 
-		uiDomain, err := readUIDomain(v)
-		if err != nil {
-			return nil, err
-		}
+			uiDomain, err := readUIDomain(v)
+			if err != nil {
+				return nil, err
+			}
 
-		webDomain, err := readWebDomain(v)
-		if err != nil {
-			return nil, err
-		}
+			webDomain, err := readWebDomain(v)
+			if err != nil {
+				return nil, err
+			}
 
-		config.ContextConfig = &APIContext{
-			APIDomain: apiDomain,
-			UIDomain:  uiDomain,
-			WebDomain: webDomain,
+			config.ContextConfig = map[string]*ContextConfig{
+				context: {
+					Domains: &APIContext{
+						APIDomain: apiDomain,
+						UIDomain:  uiDomain,
+						WebDomain: webDomain,
+					},
+				},
+			}
 		}
 	}
 
 	return config, nil
+}
+
+func WriteConfig(cfg *Config, flags *pflag.FlagSet) error {
+	v := viper.New()
+
+	v.SetEnvPrefix(RelayEnvironment)
+	v.AutomaticEnv()
+
+	readInConfigFile(v, flags)
+
+	if cfg.CurrentContext != "" {
+		v.Set("context", cfg.CurrentContext)
+	}
+
+	if cfg.ContextConfig != nil {
+		for context, config := range cfg.ContextConfig {
+			if config.Auth != nil && config.Auth.Tokens != nil {
+				tokens := config.Auth.Tokens
+				for name, value := range tokens {
+					v.Set(fmt.Sprintf("contexts.%s.auth.tokens.%s", context, name), value)
+				}
+			}
+		}
+	}
+
+	if err := v.WriteConfig(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // readInConfigFile reads config file location from viper flags, then
@@ -256,29 +328,29 @@ func readInConfigFile(v *viper.Viper, flags *pflag.FlagSet) error {
 // userConfigDir gets default user config dir
 func userConfigDir() string {
 	if os.Getenv("XDG_CONFIG_HOME") != "" {
-		return filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "relay")
+		return filepath.Join(os.Getenv("XDG_CONFIG_HOME"), RelayEnvironment)
 	}
 
-	return filepath.Join(os.Getenv("HOME"), ".config", "relay")
+	return filepath.Join(os.Getenv("HOME"), ".config", RelayEnvironment)
 }
 
 // userCacheDir gets default user cache dir, used as directory for storing tokens
 func userCacheDir() string {
 	if os.Getenv("XDG_CACHE_HOME") != "" {
-		return filepath.Join(os.Getenv("XDG_CACHE_HOME"), "relay")
+		return filepath.Join(os.Getenv("XDG_CACHE_HOME"), RelayEnvironment)
 	}
 
-	return filepath.Join(os.Getenv("HOME"), ".cache", "relay")
+	return filepath.Join(os.Getenv("HOME"), ".cache", RelayEnvironment)
 }
 
 // userDataDir gets default user data dir. The data dir is used to store long term
 // data generated by the cli.
 func userDataDir() string {
 	if os.Getenv("XDG_DATA_HOME") != "" {
-		return filepath.Join(os.Getenv("XDG_DATA_HOME"), "relay")
+		return filepath.Join(os.Getenv("XDG_DATA_HOME"), RelayEnvironment)
 	}
 
-	return filepath.Join(os.Getenv("HOME"), ".local", "share", "relay")
+	return filepath.Join(os.Getenv("HOME"), ".local", "share", RelayEnvironment)
 }
 
 // readOutput reads and validates output config value

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,19 @@ func (att AuthTokenType) String() string {
 	return string(att)
 }
 
+func AuthTokenTypes() []AuthTokenType {
+	return []AuthTokenType{AuthTokenTypeAPI, AuthTokenTypeSession}
+}
+
+func AuthTokenTypesAsString() []string {
+	authTokenTypes := make([]string, len(AuthTokenTypes()))
+	for index, tokenType := range AuthTokenTypes() {
+		authTokenTypes[index] = tokenType.String()
+	}
+
+	return authTokenTypes
+}
+
 const (
 	RelayEnvironment = "relay"
 
@@ -210,7 +223,7 @@ func FromFlags(flags *pflag.FlagSet) (*Config, error) {
 					Tokens: make(map[AuthTokenType]string),
 				}
 
-				for _, tokenType := range []AuthTokenType{AuthTokenTypeAPI, AuthTokenTypeSession} {
+				for _, tokenType := range AuthTokenTypes() {
 					token := authSection.GetString(fmt.Sprintf("tokens.%s", tokenType))
 					config.ContextConfig[context].Auth.Tokens[tokenType] = token
 				}

--- a/pkg/format/guilink.go
+++ b/pkg/format/guilink.go
@@ -8,5 +8,5 @@ import (
 )
 
 func GuiLink(cfg *config.Config, path string, a ...interface{}) string {
-	return cfg.ContextConfig.UIDomain.ResolveReference(&url.URL{Path: fmt.Sprintf(path, a...)}).String()
+	return cfg.ContextConfig[cfg.CurrentContext].Domains.UIDomain.ResolveReference(&url.URL{Path: fmt.Sprintf(path, a...)}).String()
 }

--- a/pkg/util/stdin.go
+++ b/pkg/util/stdin.go
@@ -1,6 +1,10 @@
 package util
 
-import "os"
+import (
+	"bytes"
+	"io"
+	"os"
+)
 
 func PassedStdin() (bool, error) {
 	info, err := os.Stdin.Stat()
@@ -13,4 +17,19 @@ func PassedStdin() (bool, error) {
 	}
 
 	return false, nil
+}
+
+func ReadStdin(readLimit int64) ([]byte, error) {
+	buf := bytes.Buffer{}
+	reader := &io.LimitedReader{R: os.Stdin, N: readLimit}
+
+	n, err := buf.ReadFrom(reader)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if n == 0 {
+		return nil, nil
+	}
+
+	return buf.Bytes(), nil
 }


### PR DESCRIPTION
* Token Management
  * Create, revoke, and list tokens directly from the CLI
  * Supports writing generated tokens to files
* Enhanced `auth login`
  * Import token from `stdin` or file
* CLI fully supports either token or session auth 
* Full support for multiple contexts and context switching
  * Includes auth storage support for easier context switching