### PR TITLE
Deprecated workflow add/replace for workflow save

### DIFF
--- a/docs/relay.md
+++ b/docs/relay.md
@@ -113,11 +113,6 @@ you can query repeatedly.
 
 **`relay tokens revoke [token id]`** -- Revoke API token
 
-**`relay workflow add [workflow name] [flags]`** -- Add a Relay workflow from a local file
-```
-  -f, --file string   Path to Relay workflow file
-```
-
 **`relay workflow delete [workflow name]`** -- Delete a Relay workflow
 
 **`relay workflow download [workflow name] [flags]`** -- Download a workflow from the service
@@ -127,14 +122,16 @@ you can query repeatedly.
 
 **`relay workflow list`** -- Get a list of all your workflows
 
-**`relay workflow replace [workflow name] [flags]`** -- Replace an existing Relay workflow
-```
-  -f, --file string   Path to Relay workflow file
-```
-
 **`relay workflow run [workflow name] [flags]`** -- Invoke a Relay workflow
 ```
   -p, --parameter stringArray   Parameters to invoke this workflow run with
+```
+
+**`relay workflow save [workflow name] [flags]`** -- Save a Relay workflow
+```
+  -f, --file string    Path to Relay workflow file
+  -C, --no-create      Abort instead of creating a workflow that does not exist
+  -O, --no-overwrite   Abort instead of overwriting existing revision
 ```
 
 **`relay workflow secret delete [workflow name] [secret name]`** -- Delete a Relay workflow secret

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -240,12 +240,13 @@ func parseError(resp *http.Response) errors.Error {
 	}
 
 	// Attempt to parse relay api error envelope containing an errawr
+	var cause errors.Error
 	env := &errorEnvelope{}
 	if err := json.Unmarshal(bytes, env); err == nil {
-		return env.Error.AsError()
+		cause = env.Error.AsError()
+	} else {
+		cause = errors.NewClientBadRequestBody(string(bytes))
 	}
-
-	cause := errors.NewClientBadRequestBody(string(bytes))
 
 	// otherwise return generic errors based on response code
 	switch resp.StatusCode {

--- a/pkg/cmd/workflow.go
+++ b/pkg/cmd/workflow.go
@@ -52,7 +52,6 @@ func newSaveWorkflowCommand() *cobra.Command {
 }
 
 func newAddWorkflowCommand() *cobra.Command {
-	// TODO make this imply --no-overwrite
 	cmd := &cobra.Command{
 		Use:        "add [workflow name]",
 		Short:      "Add a Relay workflow from a local file",
@@ -67,7 +66,6 @@ func newAddWorkflowCommand() *cobra.Command {
 }
 
 func newReplaceWorkflowCommand() *cobra.Command {
-	// TODO make this imply --no-replace
 	cmd := &cobra.Command{
 		Use:        "replace [workflow name]",
 		Short:      "Replace an existing Relay workflow",

--- a/pkg/cmd/workflow.go
+++ b/pkg/cmd/workflow.go
@@ -45,7 +45,7 @@ func newSaveWorkflowCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringP("file", "f", "", "Path to Relay workflow file")
-	cmd.Flags().BoolP("no-overwrite", "O", false, "Abort instead of overwriting existing revision")
+	cmd.Flags().BoolP("no-overwrite", "O", false, "Abort instead of overwriting existing workflow")
 	cmd.Flags().BoolP("no-create", "C", false, "Abort instead of creating a workflow that does not exist")
 
 	return cmd

--- a/pkg/cmd/workflow_save.go
+++ b/pkg/cmd/workflow_save.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/puppetlabs/relay/pkg/errors"
+	"github.com/puppetlabs/relay/pkg/format"
+	"github.com/puppetlabs/relay/pkg/model"
+	"github.com/spf13/cobra"
+)
+
+// TODO the `replace` command doesn't bork if --file is not supplied. It should complain
+//  it would also be nice if it checked for the file before saving the workflow, but that is extra.
+func doSaveWorkflow(cmd *cobra.Command, args []string) error {
+	workflowName, err := getWorkflowName(args)
+	if err != nil {
+		return err
+	}
+
+	var info string
+
+	Dialog.Progress("Saving workflow " + workflowName)
+
+	workflow, gerr := getOrCreateWorkflow(cmd, workflowName)
+	if gerr != nil {
+		return gerr
+	}
+
+	info = fmt.Sprintf("Successfully saved workflow %v.", workflow.Workflow.Name)
+
+	if cmd.Flags().Changed("file") {
+		info, err = updateWorkflowRevision(cmd, workflow)
+	}
+
+	Dialog.Infof(`%s
+
+View more information or update workflow settings at: %v`,
+		info,
+		format.GuiLink(Config, "/workflows/%v", workflow.Workflow.Name),
+	)
+
+	return nil
+}
+
+func getOrCreateWorkflow(cmd *cobra.Command, workflowName string) (*model.WorkflowEntity, error) {
+	workflow, err := Client.GetWorkflow(workflowName)
+	if err != nil {
+		if !errors.IsClientResponseNotFound(err) {
+			return nil, err
+		}
+
+		if cmd.Name() == "replace" {
+			return nil, errors.NewWorkflowDoesNotExistError()
+		}
+		if f := cmd.Flags().Lookup("no-create"); f != nil {
+			if noCreate, err := cmd.Flags().GetBool("no-create"); err != nil {
+				return nil, err
+			} else if noCreate {
+				return nil, errors.NewWorkflowDoesNotExistError()
+			}
+		}
+		workflow, err = Client.CreateWorkflow(workflowName)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		if cmd.Name() == "add" {
+			return nil, errors.NewWorkflowAlreadyExistsError()
+		}
+		if f := cmd.Flags().Lookup("no-overwrite"); f != nil {
+			if noOverwrite, err := cmd.Flags().GetBool("no-overwrite"); err != nil {
+				return nil, err
+			} else if noOverwrite {
+				return nil, errors.NewWorkflowAlreadyExistsError()
+			}
+		}
+	}
+
+	return workflow, err
+}
+
+func updateWorkflowRevision(cmd *cobra.Command, workflow *model.WorkflowEntity) (string, errors.Error) {
+	filePath, revisionContent, err := readFile(cmd)
+	if err != nil {
+		return "", err
+	}
+
+	info := fmt.Sprintf("Successfully saved workflow %v with file %s.", workflow.Workflow.Name, filePath)
+
+	latestRevision, err := Client.GetLatestRevision(workflow.Workflow.Name)
+	if err != nil && !errors.IsClientResponseNotFound(err) {
+		return "", err
+	}
+
+	if latestRevision != nil && latestRevision.Revision.Raw != revisionContent {
+		revision, err := Client.CreateRevision(workflow.Workflow.Name, revisionContent)
+		if err != nil {
+			Dialog.Warnf(`When uploading the file %s, we encountered the following errors:
+
+	%s
+
+	`,
+				filePath,
+				format.Error(err, cmd),
+			)
+
+			info = fmt.Sprintf("Attempted to save workflow %v, but the file content contained errors.", workflow.Workflow.Name)
+		} else {
+			wr := model.NewWorkflowRevision(workflow.Workflow, revision.Revision)
+			wr.Output(Config)
+		}
+	}
+
+	return info, nil
+}

--- a/pkg/errors/build_errors.go
+++ b/pkg/errors/build_errors.go
@@ -1267,6 +1267,102 @@ var WorkflowSection = &impl.ErrorSection{
 	Title: "Workflow errors",
 }
 
+// WorkflowAlreadyExistsErrorCode is the code for an instance of "already_exists_error".
+const WorkflowAlreadyExistsErrorCode = "rcli_workflow_already_exists_error"
+
+// IsWorkflowAlreadyExistsError tests whether a given error is an instance of "already_exists_error".
+func IsWorkflowAlreadyExistsError(err errawr.Error) bool {
+	return err != nil && err.Is(WorkflowAlreadyExistsErrorCode)
+}
+
+// IsWorkflowAlreadyExistsError tests whether a given error is an instance of "already_exists_error".
+func (External) IsWorkflowAlreadyExistsError(err errawr.Error) bool {
+	return IsWorkflowAlreadyExistsError(err)
+}
+
+// WorkflowAlreadyExistsErrorBuilder is a builder for "already_exists_error" errors.
+type WorkflowAlreadyExistsErrorBuilder struct {
+	arguments impl.ErrorArguments
+}
+
+// Build creates the error for the code "already_exists_error" from this builder.
+func (b *WorkflowAlreadyExistsErrorBuilder) Build() Error {
+	description := &impl.ErrorDescription{
+		Friendly:  "A workflow with the name provided already exists. Please provide a new name.",
+		Technical: "A workflow with the name provided already exists. Please provide a new name.",
+	}
+
+	return &impl.Error{
+		ErrorArguments:   b.arguments,
+		ErrorCode:        "already_exists_error",
+		ErrorDescription: description,
+		ErrorDomain:      Domain,
+		ErrorMetadata:    &impl.ErrorMetadata{},
+		ErrorSection:     WorkflowSection,
+		ErrorSensitivity: errawr.ErrorSensitivityNone,
+		ErrorTitle:       "Workflow name already exists",
+		Version:          1,
+	}
+}
+
+// NewWorkflowAlreadyExistsErrorBuilder creates a new error builder for the code "already_exists_error".
+func NewWorkflowAlreadyExistsErrorBuilder() *WorkflowAlreadyExistsErrorBuilder {
+	return &WorkflowAlreadyExistsErrorBuilder{arguments: impl.ErrorArguments{}}
+}
+
+// NewWorkflowAlreadyExistsError creates a new error with the code "already_exists_error".
+func NewWorkflowAlreadyExistsError() Error {
+	return NewWorkflowAlreadyExistsErrorBuilder().Build()
+}
+
+// WorkflowDoesNotExistErrorCode is the code for an instance of "does_not_exist_error".
+const WorkflowDoesNotExistErrorCode = "rcli_workflow_does_not_exist_error"
+
+// IsWorkflowDoesNotExistError tests whether a given error is an instance of "does_not_exist_error".
+func IsWorkflowDoesNotExistError(err errawr.Error) bool {
+	return err != nil && err.Is(WorkflowDoesNotExistErrorCode)
+}
+
+// IsWorkflowDoesNotExistError tests whether a given error is an instance of "does_not_exist_error".
+func (External) IsWorkflowDoesNotExistError(err errawr.Error) bool {
+	return IsWorkflowDoesNotExistError(err)
+}
+
+// WorkflowDoesNotExistErrorBuilder is a builder for "does_not_exist_error" errors.
+type WorkflowDoesNotExistErrorBuilder struct {
+	arguments impl.ErrorArguments
+}
+
+// Build creates the error for the code "does_not_exist_error" from this builder.
+func (b *WorkflowDoesNotExistErrorBuilder) Build() Error {
+	description := &impl.ErrorDescription{
+		Friendly:  "A workflow with the name provided does not exist. Please choose an existing workflow.",
+		Technical: "A workflow with the name provided does not exist. Please choose an existing workflow.",
+	}
+
+	return &impl.Error{
+		ErrorArguments:   b.arguments,
+		ErrorCode:        "does_not_exist_error",
+		ErrorDescription: description,
+		ErrorDomain:      Domain,
+		ErrorMetadata:    &impl.ErrorMetadata{},
+		ErrorSection:     WorkflowSection,
+		ErrorSensitivity: errawr.ErrorSensitivityNone,
+		ErrorTitle:       "Workflow name does not exist",
+		Version:          1,
+	}
+}
+
+// NewWorkflowDoesNotExistErrorBuilder creates a new error builder for the code "does_not_exist_error".
+func NewWorkflowDoesNotExistErrorBuilder() *WorkflowDoesNotExistErrorBuilder {
+	return &WorkflowDoesNotExistErrorBuilder{arguments: impl.ErrorArguments{}}
+}
+
+// NewWorkflowDoesNotExistError creates a new error with the code "does_not_exist_error".
+func NewWorkflowDoesNotExistError() Error {
+	return NewWorkflowDoesNotExistErrorBuilder().Build()
+}
+
 // WorkflowMissingFileFlagErrorCode is the code for an instance of "missing_file_flag_error".
 const WorkflowMissingFileFlagErrorCode = "rcli_workflow_missing_file_flag_error"
 

--- a/pkg/errors/errors.yaml
+++ b/pkg/errors/errors.yaml
@@ -127,6 +127,12 @@ sections:
       missing_name_error:
         title: Missing workflow name error
         description: Please provide a workflow name.
+      already_exists_error:
+        title: Workflow name already exists
+        description: A workflow with the name provided already exists. Please provide a new name.
+      does_not_exist_error:
+        title: Workflow name does not exist
+        description: A workflow with the name provided does not exist. Please choose an existing workflow.
   secret:
     title: Secret errors
     errors:


### PR DESCRIPTION
Prior to this commit, `relay workflow add [name] --file foo.yaml` was required to create a new workflow and `relay workflow replace [name] --file foo.yaml` was required to update an existing workflow. This meant that there was no idempotent format of the command.

This change deprecates both of these in favor of `relay workflow save [name] --file foo.yaml` that will create the workflow with the given name if it does not yet exist and will update the revision of that workflow.

There are flags to preserve the old failure modes if desired.

This change does allow `relay workflow replace [name]` (no `--file` specified) to do nothing instead of failing due to the missing flag; this behavior can be reverted if desired.