### PR TITLE
Generate latest client from OpenAPI specification

### DIFF
--- a/pkg/client/openapi/.openapi-generator-ignore
+++ b/pkg/client/openapi/.openapi-generator-ignore
@@ -10,6 +10,7 @@ docs/
 api_access_control.go
 api_auth.go
 api_billing.go
+api_connection_providers.go
 api_connections.go
 api_events.go
 api_revisions.go
@@ -42,11 +43,13 @@ model_inline_response_200_10*.go
 model_inline_response_200_11*.go
 model_inline_response_200_12*.go
 model_invite*.go
+model_o_auth2*.go
 model_profile*.go
 model_push*.go
 model_role*.go
 model_schedule*.go
 model_schema*.go
+model_secret*.go
 model_session*.go
 model_terms*.go
 model_user_all*.go

--- a/pkg/client/openapi/api_connection_providers.go
+++ b/pkg/client/openapi/api_connection_providers.go
@@ -1,0 +1,4 @@
+package openapi
+
+// ConnectionProvidersApiService ConnectionProvidersApi service
+type ConnectionProvidersApiService service

--- a/pkg/client/openapi/client.go
+++ b/pkg/client/openapi/client.go
@@ -54,6 +54,8 @@ type APIClient struct {
 
 	BillingApi *BillingApiService
 
+	ConnectionProvidersApi *ConnectionProvidersApiService
+
 	ConnectionsApi *ConnectionsApiService
 
 	EventsApi *EventsApiService
@@ -98,6 +100,7 @@ func NewAPIClient(cfg *Configuration) *APIClient {
 	c.AccessControlApi = (*AccessControlApiService)(&c.common)
 	c.AuthApi = (*AuthApiService)(&c.common)
 	c.BillingApi = (*BillingApiService)(&c.common)
+	c.ConnectionProvidersApi = (*ConnectionProvidersApiService)(&c.common)
 	c.ConnectionsApi = (*ConnectionsApiService)(&c.common)
 	c.EventsApi = (*EventsApiService)(&c.common)
 	c.NotificationsApi = (*NotificationsApiService)(&c.common)


### PR DESCRIPTION
Handles the new Connection Providers API
(this is summarily ignored for now)