### PR TITLE
User-friendly output adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,25 +39,6 @@ relay workflow list
 
 For more about workflows, check out the [Using Workflows](https://relay.sh/docs/using-workflows/) documentation.
 
-## Build
-
-To build run
-
-```bash
-./scripts/generate
-./scripts/build
-```
-
-The resulting binaries will be in `./bin/relay-[version]-[architecture]`.
-
-## Development
-
-The CLI is built entirely using go. You can run locally with
-
-```
-go run ./cmd/relay
-```
-
 ### Config
 
 Relay uses [viper](https://github.com/spf13/viper) for customizable config. The following config values may be set in a yaml file at `$HOME/.config/relay/config.yaml` or as environment variables with corresponding names in all caps, prefixed with `RELAY_`:

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -130,8 +130,8 @@ you can query repeatedly.
 **`relay workflow save [workflow name] [flags]`** -- Save a Relay workflow
 ```
   -f, --file string    Path to Relay workflow file
-  -C, --no-create      Abort instead of creating a workflow that does not exist
-  -O, --no-overwrite   Abort instead of overwriting existing revision
+  -C, --no-create      Do not create a workflow if it does not exist
+  -O, --no-overwrite   Do not overwrite an existing workflow
 ```
 
 **`relay workflow secret delete [workflow name] [secret name]`** -- Delete a Relay workflow secret

--- a/pkg/cmd/dev.go
+++ b/pkg/cmd/dev.go
@@ -113,17 +113,14 @@ func doDevWorkflowRun(cmd *cobra.Command, args []string) error {
 
 	dm := dev.NewManager(cm, cl, DevConfig)
 
-	Dialog.Info("Running workflow")
+	Dialog.Infof("Processing workflow file %s", fp)
 
 	ws, err := dm.RunWorkflow(ctx, file, parseParameters(params))
 	if err != nil {
 		return err
 	}
 
-	// FIXME Ideally this would have cognizance of the exact (generated) name of the workflow run and the namespace used
-	Dialog.Infof("Monitor step progress with: ")
-	Dialog.Infof("relay dev kubectl -n %s get workflowruns --watch", ws.WorkflowIdentifier.Name)
-	Dialog.Infof("relay dev kubectl -n %s get pods --watch", ws.WorkflowIdentifier.Name)
+	Dialog.Infof("Running workflow %s", ws.WorkflowIdentifier.Name)
 
 	return nil
 }
@@ -169,7 +166,7 @@ func doDevWorkflowSecretSet(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	Dialog.Info("Setting your secret...")
+	Dialog.Infof("Setting secret %s for workflow %s", sc.name, sc.workflowName)
 
 	return dm.SetWorkflowSecret(ctx, sc.workflowName, sc.name, sc.value)
 }

--- a/pkg/cmd/workflow.go
+++ b/pkg/cmd/workflow.go
@@ -45,8 +45,8 @@ func newSaveWorkflowCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringP("file", "f", "", "Path to Relay workflow file")
-	cmd.Flags().BoolP("no-overwrite", "O", false, "Abort instead of overwriting existing workflow")
-	cmd.Flags().BoolP("no-create", "C", false, "Abort instead of creating a workflow that does not exist")
+	cmd.Flags().BoolP("no-overwrite", "O", false, "Do not overwrite an existing workflow")
+	cmd.Flags().BoolP("no-create", "C", false, "Do not create a workflow if it does not exist")
 
 	return cmd
 }


### PR DESCRIPTION
- Removes misleading/incorrect documentation and dialog output
- Adds additional context to `relay dev` command output
- Slightly improve the overall positivity of the `relay workflow save` options
  - `go generate ./...` was missed, so might as well make adjustments and regenerate