### PR TITLE
Add go generate check to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,24 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '1.16'
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/go/pkg/sumdb
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Check
+      run: |
+        go generate ./...
+        if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+          exit 1
+        fi


### PR DESCRIPTION
Adds a `go generate ./...` check to CI to ensure this is run before merging PRs.
