### PR TITLE
Add `version` subcommand and update build script to set necessary value

### DIFF
--- a/docs/relay.md
+++ b/docs/relay.md
@@ -109,6 +109,8 @@ you can query repeatedly.
 
 **`relay tokens revoke [token id]`** -- Revoke API token
 
+**`relay version`** -- Print version
+
 **`relay workflow delete [workflow name]`** -- Delete a Relay workflow
 
 **`relay workflow download [workflow name] [flags]`** -- Download a workflow from the service

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -91,6 +91,7 @@ Use the 'workflow' subcommand to interact with workflows:
 	cmd.AddCommand(newNotificationsCommand())
 	cmd.AddCommand(newSubscriptionsCommand())
 	cmd.AddCommand(newTokensCommand())
+	cmd.AddCommand(newVersionCommand())
 
 	return cmd
 }

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/puppetlabs/relay/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+func newVersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: `Print version`,
+		Run: func(cmd *cobra.Command, args []string) {
+			v := version.GetVersion()
+			if v == "" {
+				fmt.Println("could not determine build information")
+			} else {
+				fmt.Println(v)
+			}
+		},
+	}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,16 @@
 package version
 
-const Version = "dev"
+import "runtime/debug"
+
+var Version string
+
+func GetVersion() string {
+	if Version == "" {
+		i, ok := debug.ReadBuildInfo()
+		if !ok {
+			return ""
+		}
+		Version = i.Main.Version
+	}
+	return Version
+}

--- a/scripts/build
+++ b/scripts/build
@@ -29,6 +29,6 @@ eval "$( relay::cli::cli_vars )"
 $MKDIR_P "${BIN_DIR}"
 
 set -x
-$GO build -o "${BIN_DIR}/${CLI_FILE_BIN}" -ldflags "${LDFLAGS[*]}" "./cmd/${CLI_NAME}"
+$GO build -o "${BIN_DIR}/${CLI_FILE_BIN}" -ldflags "-X github.com/puppetlabs/relay/pkg/version.Version=${CLI_VERSION} ${LDFLAGS[*]}" "./cmd/${CLI_NAME}"
 
 relay::cli::sha256sum < "${BIN_DIR}/${CLI_FILE_BIN}" > "${BIN_DIR}/${CLI_FILE_BIN}.sha256"


### PR DESCRIPTION
Not sure if the `debug.ReadBuildInfo()` fallback is really necessary here, the example I was following used it. In our case we already have a pretty robust version calculation as part of the build script that was easy to inject so it may be fine to just fallback to the "could not determine build information" output.