### PR TITLE
Resolve the existential crisis of a new cluster

### DIFF
--- a/pkg/cluster/k3d.go
+++ b/pkg/cluster/k3d.go
@@ -245,10 +245,6 @@ func (m *K3dClusterManager) clusterCreate(ctx context.Context, cfg v1alpha3.Simp
 		return err
 	}
 
-	if _, err := k3dclient.ClusterGet(ctx, runtimes.SelectedRuntime, &clusterConfig.Cluster); err != nil {
-		return err
-	}
-
 	if clusterConfig.KubeconfigOpts.UpdateDefaultKubeconfig {
 		clusterConfig.ClusterCreateOpts.WaitForServer = true
 	}


### PR DESCRIPTION
Fixes an inverted error check introduced when cleaning up error handling.

Removes the check entirely for now, as we check for the existence of a cluster elsewhere.
As a general rule, it's probably a fair expectation to expect the use of the `Exists` function prior to `Create` when using this interface.

Otherwise, this logic becomes unwieldy, as it requires checking for the lack of an error code as an error, and generating a fake error to cover this scenario, which feels decidedly unclean.

May revisit this in the future.