### PR TITLE
Update default Relay Installer image

### DIFF
--- a/pkg/dev/dev.go
+++ b/pkg/dev/dev.go
@@ -54,7 +54,7 @@ var (
 )
 
 const (
-	RelayInstallerImage                            = "relaysh/relay-install-operator:latest"
+	RelayInstallerImage                            = "relaysh/relay-installer:latest"
 	RelayLogServiceImage                           = "relaysh/relay-pls:latest"
 	RelayMetadataAPIImage                          = "relaysh/relay-metadata-api:latest"
 	RelayOperatorImage                             = "relaysh/relay-operator:latest"


### PR DESCRIPTION
Update default Relay Installer image to `relaysh/relay-installer` instead of `relaysh/relay-install-operator`. The previous use of `relaysh/relay-install-operator` was slightly inconsistent with other naming. `Relay Installer` is arguably cleaner.