### PR TITLE
Add command to configure global flags

### DIFF
--- a/docs/relay.md
+++ b/docs/relay.md
@@ -34,6 +34,12 @@ Use the 'workflow' subcommand to interact with workflows:
   -t, --type string   Authentication type (api|session)
 ```
 
+**`relay config global debug (true|false)`** -- Set global debug flag
+
+**`relay config global out (text|json)`** -- Set global out flag
+
+**`relay config global yes (true|false)`** -- Set global yes flag
+
 **`relay context set [context name]`** -- Set current context
 
 **`relay context view`** -- View current context

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/puppetlabs/relay/pkg/config"
@@ -16,6 +17,7 @@ func newConfigCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(newConfigAuthCommand())
+	cmd.AddCommand(newConfigGlobalCommand())
 
 	return cmd
 }
@@ -72,4 +74,95 @@ func doConfigAuthClear(cmd *cobra.Command, args []string) error {
 	config.WriteConfig(cfg, cmd.Flags())
 
 	return nil
+}
+
+func newConfigGlobalCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "global",
+		Short: "Manage Relay CLI global options",
+		Args:  cobra.ExactArgs(0),
+	}
+
+	cmd.AddCommand(newConfigDebugFlagCommand())
+	cmd.AddCommand(newConfigOutFlagCommand())
+	cmd.AddCommand(newConfigYesFlagCommand())
+
+	return cmd
+}
+
+func newConfigDebugFlagCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "debug (true|false)",
+		Short: "Set global debug flag",
+		Args:  cobra.ExactArgs(1),
+		RunE:  doConfigSetDebugFlag,
+	}
+
+	return cmd
+}
+
+func doConfigSetDebugFlag(cmd *cobra.Command, args []string) error {
+	debug, err := strconv.ParseBool(args[0])
+	if err != nil {
+		return err
+	}
+
+	return config.WriteGlobalConfig(&config.Config{
+		Debug: debug,
+		Out:   Config.Out,
+		Yes:   Config.Yes,
+	}, cmd.Flags())
+}
+
+func newConfigOutFlagCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "out (text|json)",
+		Short: "Set global out flag",
+		Args:  cobra.ExactArgs(1),
+		RunE:  doConfigSetOutFlag,
+	}
+
+	return cmd
+}
+func doConfigSetOutFlag(cmd *cobra.Command, args []string) error {
+	switch args[0] {
+	case config.OutputTypeJSON.String():
+		return config.WriteGlobalConfig(&config.Config{
+			Debug: Config.Debug,
+			Out:   config.OutputTypeJSON,
+			Yes:   Config.Yes,
+		}, cmd.Flags())
+	case config.OutputTypeText.String():
+		return config.WriteGlobalConfig(&config.Config{
+			Debug: Config.Debug,
+			Out:   config.OutputTypeText,
+			Yes:   Config.Yes,
+		}, cmd.Flags())
+	default:
+		return fmt.Errorf("invalid output type: %s", args[0])
+	}
+}
+
+func newConfigYesFlagCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "yes (true|false)",
+		Short: "Set global yes flag",
+		Args:  cobra.ExactArgs(1),
+		RunE:  doConfigSetYesFlag,
+	}
+
+	return cmd
+}
+
+func doConfigSetYesFlag(cmd *cobra.Command, args []string) error {
+	yes, err := strconv.ParseBool(args[0])
+	if err != nil {
+		return err
+	}
+
+	return config.WriteGlobalConfig(&config.Config{
+		Debug: Config.Debug,
+		Out:   Config.Out,
+		Yes:   yes,
+	}, cmd.Flags())
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,10 @@ const (
 	OutputTypeJSON OutputType = "json"
 )
 
+func (ot OutputType) String() string {
+	return string(ot)
+}
+
 type AuthTokenType string
 
 const (
@@ -308,6 +312,25 @@ func WriteConfig(cfg *Config, flags *pflag.FlagSet) error {
 			}
 		}
 	}
+
+	if err := v.WriteConfig(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func WriteGlobalConfig(cfg *Config, flags *pflag.FlagSet) error {
+	v := viper.New()
+
+	v.SetEnvPrefix(RelayEnvironment)
+	v.AutomaticEnv()
+
+	readInConfigFile(v, flags)
+
+	v.Set("debug", cfg.Debug)
+	v.Set("out", cfg.Out)
+	v.Set("yes", cfg.Yes)
 
 	if err := v.WriteConfig(); err != nil {
 		return err


### PR DESCRIPTION
Add commands to configure global flags. Currently, you have to either manually modify the configuration file to set global options or add the flag overrides on every command issuance. This adds an easier method (primarily for automated environments) to set global options when issuing a set of `relay` commands. Note that it still transparently requires the configuration file, due to the way the current functionality works.

This feels a bit too boilerplate, but it serves the purpose for now, without a larger rework of the underlying system.