### PR TITLE
Refactor tenant namespace for dev workflows

### DIFF
--- a/pkg/dev/dev.go
+++ b/pkg/dev/dev.go
@@ -114,7 +114,7 @@ func (m *Manager) CreateTenant(ctx context.Context, name string) (*relayv1beta1.
 		v1.WithIDTenantOption(name),
 		v1.WithWorkflowNameTenantOption(name),
 		v1.WithWorkflowIDTenantOption(name),
-		v1.WithNamespaceTenantOption(name),
+		v1.WithNamespaceTenantOption(tenantNamespace),
 	)
 
 	mapping, err := mapper.ToRuntimeObjectsManifest()
@@ -166,7 +166,7 @@ func (m *Manager) CreateWorkflow(ctx context.Context, wd *v1.WorkflowData, t *re
 
 	mapper := v1.NewDefaultWorkflowMapper(
 		v1.WithDomainIDOption(name),
-		v1.WithNamespaceOption(name),
+		v1.WithNamespaceOption(tenantNamespace),
 		v1.WithWorkflowNameOption(name),
 		v1.WithVaultEngineMountOption(VaultEngineMountCustomers),
 		v1.WithTenantOption(t),
@@ -208,7 +208,7 @@ func (m *Manager) RunWorkflow(ctx context.Context, wf *relayv1beta1.Workflow, pa
 	}
 
 	mapper := v1.NewDefaultRunEngineMapper(
-		v1.WithDomainIDRunOption(wf.GetNamespace()),
+		v1.WithDomainIDRunOption(wf.GetName()),
 		v1.WithNamespaceRunOption(wf.GetNamespace()),
 		v1.WithWorkflowNameRunOption(wf.GetName()),
 		v1.WithWorkflowRunNameRunOption(runName),

--- a/pkg/dev/namespace.go
+++ b/pkg/dev/namespace.go
@@ -20,7 +20,6 @@ const (
 
 type namespaceObjects struct {
 	systemNamespace         corev1.Namespace
-	tenantNamespace         corev1.Namespace
 	knativeServingNamespace corev1.Namespace
 	kourierSystemNamespace  corev1.Namespace
 }
@@ -28,7 +27,6 @@ type namespaceObjects struct {
 func newNamespaceObjects() *namespaceObjects {
 	return &namespaceObjects{
 		systemNamespace:         corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: systemNamespace}},
-		tenantNamespace:         corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: tenantNamespace}},
 		knativeServingNamespace: corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: knativeServingNamespace}},
 		kourierSystemNamespace:  corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: kourierSystemNamespace}},
 	}
@@ -45,12 +43,6 @@ func (m *namespaceManager) reconcile(ctx context.Context) error {
 	if _, err := ctrl.CreateOrUpdate(ctx, cl, &m.objects.systemNamespace, func() error {
 		m.systemNamespace(&m.objects.systemNamespace)
 
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	if _, err := ctrl.CreateOrUpdate(ctx, cl, &m.objects.tenantNamespace, func() error {
 		return nil
 	}); err != nil {
 		return err


### PR DESCRIPTION
Dev workflow resources are created in the `relay-tenants` namespace (consistent with our current design) instead of the target workflow namespace (legacy design). The Relay Installer is creating the `relay-tenant` namespace automatically now as well.
